### PR TITLE
perf: fix hero LCP by ungating above-fold text from scroll-reveal

### DIFF
--- a/app/layout.tsx
+++ b/app/layout.tsx
@@ -3,7 +3,7 @@ import { Space_Mono } from "next/font/google";
 import "./globals.css";
 import ModernFooter from "@/components/Footer";
 import ModernNavbar from "@/components/Navbar";
-import AnimatedBackground from "@/components/AnimatedBackground";
+import AnimatedBackground from "@/components/AnimatedBackgroundLazy";
 import { Analytics } from "@vercel/analytics/react";
 import { ThemeProvider } from "@/context/ThemeProvider";
 import { SpeedInsights } from "@vercel/speed-insights/next";

--- a/components/AnimatedBackgroundLazy.tsx
+++ b/components/AnimatedBackgroundLazy.tsx
@@ -1,0 +1,13 @@
+"use client";
+
+import dynamic from "next/dynamic";
+
+// Purely decorative, renders only after mount, and pulls in framer-motion.
+// Load it client-side so it never blocks first paint of page content.
+const AnimatedBackground = dynamic(() => import("./AnimatedBackground"), {
+  ssr: false,
+});
+
+export default function AnimatedBackgroundLazy() {
+  return <AnimatedBackground />;
+}

--- a/components/Hero.tsx
+++ b/components/Hero.tsx
@@ -1,9 +1,13 @@
 "use client";
 
 import Link from "next/link";
+import dynamic from "next/dynamic";
 import { HERO_CONSTANTS } from "@/constants/hero";
 import { useReveal } from "@/hooks/useReveal";
-import HeroCard from "./HeroCard";
+
+// Decorative, desktop-only, and heavy (framer-motion + icon packs). Keep it out
+// of the critical path so the above-the-fold hero text paints first.
+const HeroCard = dynamic(() => import("./HeroCard"), { ssr: false });
 
 const ArrowGlyph = () => (
   <svg width="12" height="12" viewBox="0 0 12 12" fill="none" aria-hidden>
@@ -24,9 +28,9 @@ const ModernHero = () => {
       <div className="max-w-page mx-auto px-6 md:px-8">
         <div className="grid grid-cols-12 gap-8">
           <div className="col-span-12 lg:col-span-7">
-            <p className="eyebrow mb-6 reveal">{HERO_CONSTANTS.eyebrow}</p>
+            <p className="eyebrow mb-6">{HERO_CONSTANTS.eyebrow}</p>
 
-            <h1 className="display text-[40px] sm:text-[56px] md:text-[72px] leading-[0.95] reveal text-fg">
+            <h1 className="display text-[40px] sm:text-[56px] md:text-[72px] leading-[0.95] text-fg">
               {headline.line1}
               <br />
               <span className="italic-serif" style={{ color: "var(--signal)" }}>
@@ -37,13 +41,13 @@ const ModernHero = () => {
               {headline.line3}
             </h1>
 
-            <p className="mt-10 max-w-[54ch] text-[17px] leading-[1.55] reveal text-fg-dim">
+            <p className="mt-10 max-w-[54ch] text-[17px] leading-[1.55] text-fg-dim">
               {description.before}
               <span className="italic-serif text-fg">{description.accent}</span>
               {description.after}
             </p>
 
-            <div className="mt-12 flex flex-wrap items-center gap-8 reveal">
+            <div className="mt-12 flex flex-wrap items-center gap-8">
               <Link
                 href="#work"
                 className="font-mono text-[12px] tracking-[0.1em] inline-flex items-center gap-3 px-6 py-4 rounded-full"


### PR DESCRIPTION
## Problem

Desktop **LCP was 3.56s** and **FCP 2.71s** despite a fast **0.29s TTFB** (per Vercel Speed Insights). The bottleneck wasn't the server — it was that the LCP element (the hero `<h1>`) was hidden until JavaScript ran.

Every hero element carried the `.reveal` class:

```css
.reveal { opacity: 0; transform: translateY(14px); transition: ... 0.9s; }
.reveal.in { opacity: 1; transform: none; }
```

`.in` is only added by the `useReveal()` client hook via IntersectionObserver, so the headline's paint timeline was: HTML arrives → download/parse/hydrate JS → effect fires → 0.9s fade → *then* LCP registers. Scroll-reveal on above-the-fold content is the anti-pattern — the content is already in view, so it just hides itself from the LCP timer.

## Changes

- **Remove `reveal` from above-the-fold hero text** (eyebrow, `<h1>`, description, CTAs) so they paint from server-rendered HTML — decouples LCP/FCP from JS entirely.
- **Lazy-load `HeroCard`** via `next/dynamic` (`ssr: false`) — it's desktop-only, decorative, and heavy (framer-motion + lucide + react-icons).
- **Defer `AnimatedBackground`** via a small client wrapper (`AnimatedBackgroundLazy`) since `layout.tsx` is a Server Component and can't use `ssr: false` directly. Keeps framer-motion off the critical path during initial load.

Below-the-fold sections (Projects, About, CTA) and the stats row keep their scroll-reveal.

## Impact

- **FCP / LCP**: largest gains — hero text now paints from static HTML instead of waiting on hydration.
- **TBT / hydration**: lighter initial JS as the card + background bundles defer.
- **CLS**: unchanged (card wrapper retains `lg:min-h-[500px]`, so no shift).

## Testing

- `npm run build` passes (TypeScript + static generation clean).
- Recommend confirming against real Speed Insights data after deploy.

🤖 Generated with [Claude Code](https://claude.com/claude-code)